### PR TITLE
zealot_version_check: 增加 action 用来构建前检查该版本是否存在

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,34 @@
-lane :test do
+lane :version_check do
+  # zealot_version_check(
+  #   endpoint: 'http://localhost:3000',
+  #   token: '...',
+  #   bundle_id: 'com.example.app.name'
+  #   release_version: '1.0.0',
+  #   build_version: '1'
+  # )
+
+  zealot_version_check(
+    endpoint: 'http://localhost:3000',
+    token: '320bacf980e20e7b058be2d77154dc53',
+    channel_key: '5baef6bd0a85e7d4bb5a98bfedd163c8',
+    bundle_id: 'com.haohaozhu.hhz',
+    git_commit: '12345678'
+    # release_version: '4.1.1',
+    # build_version: '10291524'
+  )
+end
+
+lane :upload_app do
   zealot(
+    endpoint: 'http://localhost:3000',
+    token: '...',
+    channel_key: '...',
+    file: 'app.apk'
+  )
+end
+
+lane :upload_debug_file do
+  zealot_debug_file(
     endpoint: 'http://localhost:3000',
     token: '...',
     channel_key: '...',

--- a/lib/fastlane/plugin/zealot/actions/zealot_version_check.rb
+++ b/lib/fastlane/plugin/zealot/actions/zealot_version_check.rb
@@ -1,0 +1,141 @@
+require 'fastlane/action'
+require_relative '../helper/zealot_helper'
+
+module Fastlane
+  module Actions
+    module SharedValues
+      ZEALOT_APP_VERSION_EXISTED = :ZEALOT_APP_VERSION_EXISTED
+    end
+
+    class ZealotVersionCheckAction < Action
+      extend Fastlane::Helper::ZealotHelper
+
+      def self.run(params)
+        response = check_app_version(params)
+        parse_response(response, params[:fail_on_error])
+      end
+
+      def self.parse_response(response, fail_on_error)
+        UI.verbose "[status] #{response.status}"
+        UI.verbose "[body] #{response.body}"
+
+        is_existed = case response.status
+                     when 200 then true
+                     when 404 then false
+                     end
+
+        return show_error(response.body['error'], fail_on_error) if is_existed.nil?
+
+        Actions.lane_context[SharedValues::ZEALOT_APP_VERSION_EXISTED] = is_existed
+
+        if is_existed
+          UI.important 'Found app version, you can skip upload it'
+        else
+          UI.success 'Not found app version, you can upload it'
+        end
+
+        is_existed
+      end
+      private_class_method :parse_response
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Check app version exists from Zealot'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :endpoint,
+                                       env_name: 'ZEALOT_ENDPOINT',
+                                       description: 'The endpoint of zealot',
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :token,
+                                       env_name: 'ZEALOT_TOKEN',
+                                       description: 'The token of user',
+                                       sensitive: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No user token for Zealot given, pass using `token: 'token'`") if value.nil? || value.empty?
+                                       end,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :channel_key,
+                                       env_name: 'ZEALOT_CHANNEL_KEY',
+                                       description: 'The key of app\'s channel',
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :bundle_id,
+                                       env_name: 'ZEALOT_BUNDLE_ID',
+                                       description: 'The bundle id(package name) of app',
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :release_version,
+                                       env_name: 'ZEALOT_RELEASE_VERSION',
+                                       description: 'The release version of app',
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :build_version,
+                                       env_name: 'ZEALOT_BUILD_VERSION',
+                                       description: 'The build version of app',
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :git_commit,
+                                       env_name: 'ZEALOT_GIT_COMMIT',
+                                       description: 'The latest git commit of app',
+                                       default_value: ENV['GIT_COMMIT'] || ENV['CI_COMMIT_SHA'],
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :fail_on_error,
+                                       env_name: 'ZEALOT_FAIL_ON_ERROR',
+                                       description: 'Should an error http request cause a failure? (true/false)',
+                                       optional: true,
+                                       default_value: false,
+                                       type: Boolean)
+        ]
+      end
+
+      def self.example_code
+        [
+          'zealot_version_check(
+            endpoint: "...",
+            token: "...",
+            channel_key: "...",
+            bundle_id: "im.ews.zealot",
+            git_commit: "ec7b5859f77882892325840eae0716fcaab6c14f"
+          )',
+          'zealot_version_check(
+            endpoint: "...",
+            token: "...",
+            channel_key: "...",
+            bundle_id: "im.ews.zealot",
+            release_version: "1.0.0",
+            build_version: "1"
+          )',
+        ]
+      end
+
+      def self.output
+        [
+          [
+            'ZEALOT_APP_VERSION_EXISTED', 'The result of app verison existed (Boolean)'
+          ]
+        ]
+      end
+
+      def self.return_value
+        Boolean
+      end
+
+      def self.category
+        :beta
+      end
+
+      def self.authors
+        ['icyleaf']
+      end
+
+      def self.is_supported?(_)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/zealot/helper/zealot_helper.rb
+++ b/lib/fastlane/plugin/zealot/helper/zealot_helper.rb
@@ -4,12 +4,86 @@ module Fastlane
   UI = FastlaneCore::UI unless Fastlane.const_defined?("UI")
 
   module Helper
-    class ZealotHelper
-      # class methods that you define here become available in your action
-      # as `Helper::ZealotHelper.your_method`
-      #
-      def self.show_message
-        UI.message("Hello from the zealot plugin helper!")
+    module ZealotHelper
+      def check_app_version(params)
+        query = build_app_version_check_params(params)
+        print_table(query, title: 'zealot_version_check', hidden_keys: ['token'])
+
+        UI.success("Checking app version from Zealot ...")
+        connection = make_connection(params[:endpoint])
+        connection.get do |req|
+          req.url '/api/apps/version_exist'
+          req.params = query
+        end
+      rescue Faraday::Error::TimeoutError
+        show_error('Check app version from Zealot timed out ⏳', params[:fail_on_error])
+      end
+
+      def build_app_version_check_params(params)
+        token = params[:token]
+        channel_key = params[:channel_key]
+        bundle_id = params[:bundle_id]
+        release_version = params[:release_version]
+        build_version = params[:build_version]
+        git_commit = params[:git_commit]
+
+        UI.user_error! 'bundle id is missing' if bundle_id.to_s.empty?
+
+        has_version = !(release_version.to_s.empty? && build_version.to_s.empty?)
+        has_git_commit = !git_commit.to_s.empty?
+        UI.user_error! 'release_version + build_version or git_commit is missing' unless has_version || has_git_commit
+
+        if has_version
+          {
+            token: token,
+            channel_key: channel_key,
+            bundle_id: bundle_id,
+            release_version: release_version,
+            build_version: build_version
+          }
+        else
+          {
+            token: token,
+            channel_key: channel_key,
+            bundle_id: bundle_id,
+            git_commit: git_commit
+          }
+        end
+      end
+
+      def make_connection(endpoint)
+        require 'faraday'
+        require 'faraday_middleware'
+
+        Faraday.new(url: endpoint) do |builder|
+          builder.request(:multipart)
+          builder.request(:url_encoded)
+          builder.request(:retry, max: 3, interval: 5)
+          builder.response(:json, content_type: /\bjson$/)
+          builder.adapter(:net_http)
+        end
+      end
+
+      def print_table(form, title: 'zealot', hidden_keys: [], remove_empty_value: true)
+        rows = form.dup
+        rows.keys.each do |k|
+          rows.delete(k) if remove_empty_value && !rows[k]
+          rows.delete(k) if hidden_keys.include?(k.to_s)
+        end
+        puts Terminal::Table.new(
+          title: "Summary for #{title} #{Fastlane::Zealot::VERSION}".green,
+          rows: rows
+        )
+      end
+
+      def show_error(message, fail_on_error)
+        if fail_on_error
+          UI.user_error!(message)
+        else
+          UI.error(message)
+        end
+
+        false
       end
     end
   end


### PR DESCRIPTION
**目的**：花了好长时间打包完成开始上传结果告知此版本已存在，如何避免这样的事情发生利用 zealot  在使用 Jenkins 或 Gitlab CI 上传 app 时会自动附带上 git commit，因此对于已经上传的应用可以通过一些方式进行检查，目前提供两种方式检查：

- 通过 bundle_id, git_commit
- 通过 bundle_id, release_version 和 build_version

该 action 会返回 Boolean 类型同时也会保存到  `Actions.lane_context` 中，Key 是 `SharedValues::ZEALOT_APP_VERSION_EXISTED`

用例：

```ruby
existed = zealot_version_check(
  endpoint: "...",
  token: "...",
  channel_key: "...",
  bundle_id: "im.ews.zealot",
  git_commit: "ec7b5859f77882892325840eae0716fcaab6c14f"
)

# Or
zealot_version_check(
  endpoint: "...",
  token: "...",
  channel_key: "...",
  bundle_id: "im.ews.zealot",
  release_version: "1.0.0",
  build_version: "1"
)
existed = Actions.lane_context[SharedValues::ZEALOT_APP_VERSION_EXISTED]
```