### PR TITLE
添加 zealot_debug_file action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 > 如下罗列的变更是还未发布的列表
 
-## 新增
+### 新增
 
 - 新增 zealot action
 - 新增 zealot_version_check action

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,6 @@ gemspec
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)
+
+gem 'debase'
+gem 'ruby-debug-ide'

--- a/fastlane-plugin-zealot.gemspec
+++ b/fastlane-plugin-zealot.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency
 
-  # spec.add_dependency 'your-dependency', '~> 1.0.0'
+  spec.add_dependency 'fastlane-plugin-debug_file', '~> 0.1.1'
 
   spec.add_development_dependency('pry')
   spec.add_development_dependency('bundler')

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,7 +2,7 @@ lane :version_check do
   zealot_version_check(
     endpoint: 'http://localhost:3000',
     token: '...',
-    bundle_id: 'com.example.app.name'
+    bundle_id: 'com.example.app.name',
     release_version: '1.0.0',
     build_version: '1'
   )
@@ -17,11 +17,23 @@ lane :upload_app do
   )
 end
 
-# lane :upload_debug_file do
-#   zealot_debug_file(
-#     endpoint: 'http://localhost:3000',
-#     token: '...',
-#     channel_key: '...',
-#     file: 'app.apk'
-#   )
-# end
+lane :upload_debug_file do
+  zealot_debug_file(
+    endpoint: 'http://localhost:3000',
+    token: '...',
+    channel_key: '...',
+    platform: :ios,
+    xcode_scheme: 'AppName',
+    overwrite: true
+  )
+
+  zealot_debug_file(
+    endpoint: 'http://localhost:3000',
+    token: '...',
+    channel_key: '...',
+    platform: :android,
+    android_build_type: 'release',
+    android_flavor: 'store',
+    overwrite: true
+  )
+end

--- a/lib/fastlane/plugin/zealot/actions/zealot_action.rb
+++ b/lib/fastlane/plugin/zealot/actions/zealot_action.rb
@@ -109,6 +109,7 @@ module Fastlane
                                        env_name: 'ZEALOT_GIT_COMMIT',
                                        description: 'The hash of git commit',
                                        optional: true,
+                                       default_value: ENV['GIT_COMMIT'] || ENV['CI_COMMIT_SHA'],
                                        type: String),
           FastlaneCore::ConfigItem.new(key: :password,
                                        env_name: 'ZEALOT_PASSWORD',

--- a/lib/fastlane/plugin/zealot/actions/zealot_debug_file.rb
+++ b/lib/fastlane/plugin/zealot/actions/zealot_debug_file.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require 'fastlane/action'
+require_relative '../helper/zealot_helper'
+require 'fastlane/plugin/debug_file'
+
+module Fastlane
+  module Actions
+    class ZealotDebugFileAction < Action
+      extend Fastlane::Helper::ZealotHelper
+
+      PLATFORM = %I[ios mac macos osx android].freeze
+
+      def self.run(params)
+        file = generate_zip_file(params)
+        UI.user_error! "Something wrong with compress debug file" unless file
+
+        response = upload_debug_file(params, file)
+        if parse_response(response, params[:endpoint], params[:fail_on_error])
+          UI.success('Build successfully uploaded to Zealot.')
+          # UI.success("Release URL: #{Actions.lane_context[SharedValues::ZEALOT_RELEASE_URL]}")
+          # UI.success("QRCode URL: #{Actions.lane_context[SharedValues::ZEALOT_QRCODE_URL]}")
+          # UI.success("Download URL: #{Actions.lane_context[SharedValues::ZEALOT_INSTALL_URL]}")
+        end
+      end
+
+      def self.generate_zip_file(params)
+        new_params = params.all_keys.each_with_object({}) do |key, obj|
+          next unless value = params[key]
+          obj[key] = value
+        end
+        path = new_params.delete(:path)
+        platform = new_params[:platform]
+
+        case platform
+        when :ios, :mac, :macos, :osx
+          generate_dsym_zip(new_params, path)
+        when :android
+          generate_proguard_zip(new_params, path)
+        else
+          UI.user_error!("No match value of platform: #{value}, avaiable value are #{PLATFORM.join(',')}.")
+        end
+      end
+
+      def self.generate_dsym_zip(params, path)
+        params[:archive_path] = if path
+          path
+        else
+          Actions.lane_context[SharedValues::XCODEBUILD_ARCHIVE] || Fastlane::Actions::DsymAction::ARCHIVE_PATH
+        end
+
+        params[:scheme] = params.delete(:xcode_scheme)
+        Fastlane::Actions::DsymAction.run(params)
+      end
+
+      def self.generate_proguard_zip(params, path)
+        params[:app_path] = path if path && !path.empty?
+        params[:build_type] = params.delete(:android_build_type)
+        params[:flavor] = params.delete(:android_flavor)
+        Fastlane::Actions::ProguardAction.run(params)
+      end
+
+      def self.parse_response(response, upload_url, fail_on_error)
+        return show_error("Error uploading to Zealot: empty response", fail_on_error) unless response
+
+        UI.verbose response.body.to_s
+
+        if (body = response.body) && (error = body['error'])
+          return show_error("Error uploading to Zealot: #{response.body}", fail_on_error)
+        end
+
+        # Actions.lane_context[SharedValues::ZEALOT_RELEASE_URL] = body['release_url']
+        # Actions.lane_context[SharedValues::ZEALOT_INSTALL_URL] = body['install_url']
+        # Actions.lane_context[SharedValues::ZEALOT_QRCODE_URL] = body['qrcode_url']
+
+        true
+      end
+      private_class_method :parse_response
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        'Upload a new build to Zealot'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :endpoint,
+                                       env_name: 'ZEALOT_ENDPOINT',
+                                       description: 'The endpoint of zealot',
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :token,
+                                       env_name: 'ZEALOT_TOKEN',
+                                       description: 'The token of user',
+                                       sensitive: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No user token for Zealot given, pass using `token: 'token'`") if value.nil? || value.empty?
+                                       end,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :channel_key,
+                                       env_name: 'ZEALOT_CHANNEL_KEY',
+                                       description: 'The key of app\'s channel',
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :platform,
+                                       env_name: 'ZEALOT_PLATFORM',
+                                       description: "The name of platfrom, avaiable value are #{PLATFORM.join(',')}",
+                                       verify_block: proc do |value|
+                                         UI.user_error!("No match value of platform: #{value}") unless PLATFORM.include?(value)
+                                       end,
+                                       type: :Symbol),
+          FastlaneCore::ConfigItem.new(key: :path,
+                                       env_name: 'ZEALOT_PATH',
+                                       description: 'The path of debug file (iOS/macOS is archive path for Xcode, Android is path for app project)',
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :xcode_scheme,
+                                       env_name: 'ZEALOT_XCODE_SCHEME',
+                                       description: 'The scheme name of app',
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :android_build_type,
+                                       env_name: 'ZEALOT_ANDROID_BUILD_TYPE',
+                                       description: 'The build type of app',
+                                       default_value: Fastlane::Actions::ProguardAction::RELEASE_TYPE,
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :android_flavor,
+                                       env_name: 'ZEALOT_ANDROID_FLAVOR',
+                                       description: 'The product flavor of app',
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :extra_files,
+                                       env_name: 'ZEALOT_EXTRA_FILES',
+                                       description: 'A set file names',
+                                       optional: true,
+                                       default_value: [],
+                                       type: Array),
+          FastlaneCore::ConfigItem.new(key: :output_path,
+                                       env_name: 'DF_DSYM_OUTPUT_PATH',
+                                       description: "The output path of compressed dSYM file",
+                                       default_value: '.',
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :release_version,
+                                       env_name: 'ZEALOT_RELEASE_VERSION',
+                                       description: 'The release version of app',
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :build_version,
+                                       env_name: 'ZEALOT_BUILD_VERSION',
+                                       description: 'The build version of app',
+                                       optional: true,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :overwrite,
+                                       env_name: 'DF_DSYM_OVERWRITE',
+                                       description: "Overwrite output compressed file if it existed",
+                                       default_value: false,
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :timeout,
+                                       env_name: 'ZEALOT_TIMEOUT',
+                                       description: 'Request timeout in seconds',
+                                       type: Integer,
+                                       optional: true),
+          FastlaneCore::ConfigItem.new(key: :verify_ssl,
+                                       env_name: 'ZEALOT_VERIFY_SSL',
+                                       description: 'Should verify SSL of zealot service',
+                                       optional: true,
+                                       default_value: true,
+                                       type: Boolean),
+          FastlaneCore::ConfigItem.new(key: :fail_on_error,
+                                       env_name: 'ZEALOT_FAIL_ON_ERROR',
+                                       description: 'Should an error uploading app cause a failure? (true/false)',
+                                       optional: true,
+                                       default_value: false,
+                                       type: Boolean)
+        ]
+      end
+
+      def self.example_code
+        [
+          'zealot_debug_file(
+            endpoint: "...",
+            token: "...",
+            channel_key: "...",
+            zip_file: "...",
+            release_version: "...",
+            build_version: "..."
+          )'
+        ]
+      end
+
+      def self.output
+        [
+          [
+            'ZEALOT_RELEASE_URL', 'The release URL of the newly uploaded build',
+            'ZEALOT_INSTALL_URL', 'The install URL of the newly uploaded build',
+            'ZEALOT_QRCODE_URL', 'The QRCode URL of the newly uploaded build'
+          ]
+        ]
+      end
+
+      def self.category
+        :misc
+      end
+
+      def self.authors
+        ['icyleaf']
+      end
+
+      def self.is_supported?(_)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/zealot/helper/zealot_helper.rb
+++ b/lib/fastlane/plugin/zealot/helper/zealot_helper.rb
@@ -7,6 +7,36 @@ module Fastlane
 
   module Helper
     module ZealotHelper
+      def upload_debug_file(params, file)
+        form = upload_debug_file_params(params, file)
+        print_table(form, title: 'zealot_debug_file')
+
+        endpoint = params[:endpoint]
+        UI.success("Uploading to #{endpoint} ...")
+        connection = make_connection(params[:endpoint], params[:verify_ssl])
+        begin
+          connection.post do |req|
+            req.url('/api/debug_files/upload')
+            req.options.timeout = params[:timeout]
+            req.body = form
+          end
+        rescue Faraday::Error::TimeoutError
+          show_error('Uploading build to Zealot timed out ⏳', params[:fail_on_error])
+        end
+      end
+
+      def upload_debug_file_params(params, file)
+        {
+          token: params[:token],
+          channel_key: params[:channel_key],
+          release_version: params[:release_version],
+          build_version: params[:build_version],
+          file: Faraday::UploadIO.new(file, 'application/octet-stream')
+        }
+      end
+
+      #######################################
+
       def upload_app(params)
         form = upload_app_params(params)
         print_table(form, title: 'zealot', hidden_keys: [:token])

--- a/lib/fastlane/plugin/zealot/helper/zealot_helper.rb
+++ b/lib/fastlane/plugin/zealot/helper/zealot_helper.rb
@@ -39,6 +39,9 @@ module Fastlane
 
       def upload_app(params)
         form = upload_app_params(params)
+        # recommand generate collect changelog plugin: https://github.com/icyleaf/fastlane-plugin-ci_changelog
+        form[:changelog] = changelog_raw if changelog_raw = ENV['CICL_CHANGLOG']
+
         print_table(form, title: 'zealot', hidden_keys: [:token])
 
         endpoint = params[:endpoint]

--- a/lib/fastlane/plugin/zealot/version.rb
+++ b/lib/fastlane/plugin/zealot/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Zealot
-    VERSION = "0.1.0"
+    VERSION = "0.2.0.beta1"
   end
 end


### PR DESCRIPTION
## iOS

自动搜寻指定 `xcode_scheme` 的 xarchive 的 dsym 并选择最新创建的版本进行上传

```ruby
  zealot_debug_file(
    endpoint: 'http://localhost:3000',
    token: '...',
    channel_key: '...',
    platform: :ios,
    xcode_scheme: 'AppName'
  )
```

## Android

根据指定的 `app_path` 搜寻 manifest.xml, mapping.txt 和 R.txt 并打包后进行上传

```ruby
  zealot_debug_file(
    endpoint: 'http://localhost:3000',
    token: '...',
    channel_key: '...',
    platform: :android,
    android_build_type: 'release',
    android_flavor: 'store',
    release_version: '1.0.0',
    build_version: '1'
  )
```

#3 