### PR TITLE
zealot_debug_file: 支持使用给定 zip_file 上传

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,9 +2,9 @@ lane :version_check do
   zealot_version_check(
     endpoint: 'http://localhost:3000',
     token: '...',
-    bundle_id: 'com.example.app.name',
-    release_version: '1.0.0',
-    build_version: '1'
+    channel_key: '...',
+    bundle_id: '...',
+    git_commit: last_git_commit[:commit_hash]
   )
 end
 
@@ -27,15 +27,17 @@ lane :upload_app do
 end
 
 lane :upload_debug_file do
+  # 上传 iOS dSYM 调试文件
   zealot_debug_file(
     endpoint: 'http://localhost:3000',
     token: '...',
     channel_key: '...',
     platform: :ios,
     xcode_scheme: 'AppName',
-    overwrite: true
+    verify_ssl: false
   )
 
+  # 上传 Android Proguard 调试文件
   zealot_debug_file(
     endpoint: 'http://localhost:3000',
     token: '...',
@@ -43,14 +45,27 @@ lane :upload_debug_file do
     platform: :android,
     android_build_type: 'release',
     android_flavor: 'store',
+    release_version: '1.1.0',
+    build_version: '1',
     overwrite: true
+  )
+
+  # 上传指定 zip file 调试文件
+  zealot_debug_file(
+    endpoint: 'http://localhost:3000',
+    token: '...',
+    channel_key: '...',
+    zip_file: 'path/to/your/zip_file',
+    release_version: '1.1.0',
+    build_version: '1',
+    verify_ssl: false
   )
 end
 
 lane :sync do
   zealot_sync_devices(
     endpoint: 'http://localhost:3000',
-    token: '320bacf980e20e7b058be2d77154dc53',
-    username: 'icyleaf@ews.im'
+    token: '...',
+    username: 'apple_developer_email'
   )
 end


### PR DESCRIPTION
考虑到已经打包好了调试文件不需要自动搜寻逻辑，增加了使用给定的 zip_file 进行上传：

```ruby
  zealot_debug_file(
    endpoint: 'http://localhost:3000',
    token: '...',
    channel_key: '...',
    zip_file: 'path/to/your/zip_file',
    release_version: '1.0.0',
    build_version: '1'
  )
```

同时还优化了一些代码逻辑：

1. 增加平台判断逻辑
2. 纠正一些错别字
3. 对 iOS 的 xcode_scheme 增加判空
4. 上传后显示解析的信息

```
+-----------------+-----------------------------------------------+
|               Uploaded debug file information                   |
+-----------------+-----------------------------------------------+
| id              | 15                                            |
| app_name        | Name                                          |
| device_type     | ios                                           |
| release_version | 1.1.0                                         |
| build_version   | 1.0                                           |
| file_url        | http://localhost:3000/download/debug_files/15 |
| metadata (2)    | id: 27                                        |
|                 | debug_file_id: 15                             |
|                 | uuid: 61839e1f-3cf7-3f0b-a1c7-04ea9c6aa1e5    |
|                 | type: armv7                                   |
|                 | object: Name                                  |
|                 | data: {}                                      |
|                 | size: 54418435                                |
|                 | created_at: 2020-09-15T16:36:51.952+08:00     |
|                 | updated_at: 2020-09-15T16:36:51.952+08:00     |
|                 | -------------------------                     |
|                 | id: 28                                        |
|                 | debug_file_id: 15                             |
|                 | uuid: d37696ee-0ce5-30c2-9336-6f410fc7e4ef    |
|                 | type: arm64                                   |
|                 | object: Name                                  |
|                 | data: {}                                      |
|                 | size: 57987538                                |
|                 | created_at: 2020-09-15T16:36:51.957+08:00     |
|                 | updated_at: 2020-09-15T16:36:51.957+08:00     |
+-----------------+-----------------------------------------------+
```

关联 #3